### PR TITLE
Generated Go code should use specific dbus lib version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/amenzhinsky/dbus-codegen-go
 
-require github.com/godbus/dbus v0.0.0-20181101234600-2ff6f7ffd60f
+require github.com/godbus/dbus/v5 v5.0.0-00010101000000-000000000000
+
+replace github.com/godbus/dbus/v5 => github.com/opendoor-labs/dbus/v5 v5.0.6
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/godbus/dbus v0.0.0-20181101234600-2ff6f7ffd60f h1:zlOR3rOlPAVvtfuxGKoghCmop5B0TRyu/ZieziZuGiM=
-github.com/godbus/dbus v0.0.0-20181101234600-2ff6f7ffd60f/go.mod h1:/YcGZj5zSblfDWMMoOzV4fas9FZnQYTkDnsGvmh2Grw=
+github.com/opendoor-labs/dbus/v5 v5.0.6 h1:rDS0tS8kBK+AnrFpkBeRmq2cDWFIsbhfajw+5/Tl8KU=
+github.com/opendoor-labs/dbus/v5 v5.0.6/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=

--- a/main.go
+++ b/main.go
@@ -12,8 +12,8 @@ import (
 	"github.com/amenzhinsky/dbus-codegen-go/parser"
 	"github.com/amenzhinsky/dbus-codegen-go/printer"
 	"github.com/amenzhinsky/dbus-codegen-go/token"
-	"github.com/godbus/dbus"
-	"github.com/godbus/dbus/introspect"
+	"github.com/godbus/dbus/v5"
+	"github.com/godbus/dbus/v5/introspect"
 )
 
 var (

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/amenzhinsky/dbus-codegen-go/token"
-	"github.com/godbus/dbus/introspect"
+	"github.com/godbus/dbus/v5/introspect"
 )
 
 // Parse parses the given introspection XML into a list of interfaces.

--- a/printer/printer.go
+++ b/printer/printer.go
@@ -86,7 +86,7 @@ import (
 	"fmt"
 {{end}}
 
-	"github.com/godbus/dbus"
+	"github.com/godbus/dbus/v5"
 )
 
 {{if haveSignals .Interfaces}}


### PR DESCRIPTION
While not totally necessary, I also update the deps in this package to use ODs fork of the dbus lib.

Example: 
```
go run main.go org.freedesktop.systemd1.xml | grep -A 10 import
import (
	"context"

	"errors"
	"fmt"

	"github.com/godbus/dbus/v5"
)

// Signal is a common interface for all signals.
type Signal interface {
﻿
```
